### PR TITLE
Support connecting to statsd server via unix socket

### DIFF
--- a/flask_datadog.py
+++ b/flask_datadog.py
@@ -90,17 +90,19 @@ class StatsD(object):
         self.config.setdefault('STATSD_PORT', 8125)
         self.config.setdefault('STATSD_TAGS', None)
         self.config.setdefault('STATSD_USEMS', False)
+        self.config.setdefault('STATSD_SOCKET_PATH', None)
 
         self.app = app
 
         # Configure DogStatsd client
-        # https://github.com/DataDog/datadogpy/blob/v0.11.0/datadog/dogstatsd/base.py
+        # https://github.com/DataDog/datadogpy/blob/v0.20.0/datadog/dogstatsd/base.py
         self.statsd = DogStatsd(host=self.config['STATSD_HOST'],
                                 port=self.config['STATSD_PORT'],
                                 max_buffer_size=self.config['STATSD_MAX_BUFFER_SIZE'],
                                 namespace=self.config['STATSD_NAMESPACE'],
                                 constant_tags=self.config['STATSD_TAGS'],
-                                use_ms=self.config['STATSD_USEMS'])
+                                use_ms=self.config['STATSD_USEMS'],
+                                socket_path=self.config['STATSD_SOCKET_PATH'])
 
         # Configure any of our middleware
         self.setup_middleware()

--- a/setup.py
+++ b/setup.py
@@ -12,7 +12,7 @@ setup(
     zip_safe=False,
     include_package_data=True,
     platforms='any',
-    install_requires=['Flask', 'datadog'],
+    install_requires=['Flask', 'datadog>=0.17'],
     classifiers=[
         'Environment :: Web Environment',
         'Intended Audience :: Developers',


### PR DESCRIPTION
Allow sending statsd packets via configurable unix socket, which was released in v0.17: https://github.com/DataDog/datadogpy/releases/tag/v0.17.0